### PR TITLE
ログイン成功失敗時にユーザにMessageを表示する

### DIFF
--- a/app/Http/Controllers/Auth/SocialController.php
+++ b/app/Http/Controllers/Auth/SocialController.php
@@ -48,12 +48,12 @@ class SocialController extends Controller
             return redirect('/login');
         }
 
-        $userEntity = $this->authDomainService->socialRegisterUser($socialUser);
         $result = $this->authDomainService->socialLogin($socialServiceName, $socialUser);
         if (!$result) {
             return back()->with('message', 'ログインに失敗しました');
         }
 
+        $userEntity = $this->authDomainService->socialRegisterUser($socialUser);
         return redirect('/home')->with('message', 'ようこそ '.$userEntity->getUserName().' さん');
     }
 }

--- a/app/Http/Controllers/Auth/SocialController.php
+++ b/app/Http/Controllers/Auth/SocialController.php
@@ -48,9 +48,12 @@ class SocialController extends Controller
             return redirect('/login');
         }
 
-        $this->authDomainService->socialRegisterUser($socialUser);
-        $this->authDomainService->socialLogin($socialServiceName, $socialUser);
+        $userEntity = $this->authDomainService->socialRegisterUser($socialUser);
+        $result = $this->authDomainService->socialLogin($socialServiceName, $socialUser);
+        if (!$result) {
+            return back()->with('message', 'ログインに失敗しました');
+        }
 
-        return redirect()->to('/home');
+        return redirect('/home')->with('message', 'ようこそ '.$userEntity->getUserName().' さん');
     }
 }

--- a/app/Http/Controllers/Auth/SocialController.php
+++ b/app/Http/Controllers/Auth/SocialController.php
@@ -48,12 +48,13 @@ class SocialController extends Controller
             return redirect('/login');
         }
 
+        $userEntity = $this->authDomainService->socialRegisterUser($socialUser);
+        
         $result = $this->authDomainService->socialLogin($socialServiceName, $socialUser);
         if (!$result) {
             return back()->with('message', 'ログインに失敗しました');
         }
 
-        $userEntity = $this->authDomainService->socialRegisterUser($socialUser);
         return redirect('/home')->with('message', 'ようこそ '.$userEntity->getUserName().' さん');
     }
 }

--- a/domain/Entities/UserEntity.php
+++ b/domain/Entities/UserEntity.php
@@ -55,6 +55,14 @@ class UserEntity implements Arrayable
     /**
      * @return string
      */
+    public function getUserName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
     public function getUserEmail(): string
     {
         return $this->email;

--- a/domain/Services/AuthService.php
+++ b/domain/Services/AuthService.php
@@ -119,7 +119,7 @@ class AuthService
     {
         $socialUserAccountEntity = $this->synchronizeSocialAccount($socialServiceName, $socialUser);
 
-        if ($socialUserAccountEntity->getSocialServiceName() !== $socialServiceName) {
+        if ($socialUserAccountEntity->getSocialServiceName() != $socialServiceName) {
             \Log::info("\n【ERROR】Authentication drivers do not match\n"
                 .'Entity:'.$socialUserAccountEntity->getSocialServiceName().':'.$socialUserAccountEntity->getSocialUserId()."\n"
                 .'Request:'.$socialServiceName.':'.$socialUser->getId()
@@ -127,7 +127,7 @@ class AuthService
             return false;
         }
 
-        if ($socialUserAccountEntity->getSocialUserId() !== $socialUser->getId()) {
+        if ($socialUserAccountEntity->getSocialUserId() != $socialUser->getId()) {
             \Log::info("\n【ERROR】It does not match the ID of SNS Account\n"
                 .'Entity:'.$socialUserAccountEntity->getSocialServiceName().':'.$socialUserAccountEntity->getSocialUserId()."\n"
                 .'Request:'.$socialServiceName.':'.$socialUser->getId()

--- a/domain/Services/AuthService.php
+++ b/domain/Services/AuthService.php
@@ -5,6 +5,7 @@ namespace Domain\Services;
 use Auth;
 use Exception;
 use Domain\Entities\{
+    UserEntity,
     UserDetailEntity,
     SocialUserAccountEntity
 };
@@ -99,15 +100,19 @@ class AuthService
 
     /**
      * @param SocialUser $socialUser
+     * @return UserEntity
      * @throws Exception
      */
-    public function socialRegisterUser(SocialUser $socialUser)
+    public function socialRegisterUser(SocialUser $socialUser): UserEntity
     {
         $userEntity = $this->socialRepository->findUser($socialUser);
         if (is_null($userEntity)) {
             $this->hasSocialRequiredInformation($socialUser);
             $this->socialRepository->registerUser($socialUser);
+            $userEntity = $this->socialRepository->findUser($socialUser);
         }
+
+        return $userEntity;
     }
 
     /**


### PR DESCRIPTION
# IssuesNumber

- #78 

# SocialログインでUserEntityを利用している理由

手動ログインの場合は認証の判定のためにユーザの詳細情報を必要とするため、
`UserDetailEntity` を必要としたが、Socialログインの場合は必要になる情報が異なるため
Messageを生成するのに最低限必要な `UserEntity` のみを利用している

# Socialログイン時の判定条件を変更した理由

もともと完全一致(型を含めた)を想定していましたが、
APIの返り値の型は提供元によってばらつきがありました
yoshinaniが利用しているFacebookとtwitterは`string` でgithubは `int`
よく考えてみたら一致さえしていればいいので、
型までは必要がないと思ったので、等価比較に変更しました
